### PR TITLE
Changed configuration file logic

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    massa (0.1.5)
+    massa (0.1.6)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/massa.rb
+++ b/lib/massa.rb
@@ -5,4 +5,5 @@ end
 
 require 'massa/cli'
 require 'massa/tool'
+require 'massa/command'
 require 'massa/analyzer'

--- a/lib/massa/command.rb
+++ b/lib/massa/command.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+module Massa
+  class Command
+    attr_reader :description, :command
+
+    def initialize(yaml)
+      @description = yaml['description']
+      @required    = yaml['required']
+      @gem         = yaml['gem']
+      @command     = yaml['command']
+    end
+
+    def required?
+      @required.nil? ? true : @required
+    end
+
+    def gem?
+      @gem.nil? ? true : @gem
+    end
+  end
+end

--- a/lib/massa/tool.rb
+++ b/lib/massa/tool.rb
@@ -4,21 +4,18 @@ module Massa
   class Tool
     class << self
       def list
-        default_tools.each_with_object({}) do |(tool, options), hash|
-          hash[tool] = options.merge(custom_tools[tool] || {})
-          hash
-        end
+        custom_tools.empty? ? default_tools : custom_tools
       end
 
       private
 
       def default_tools
-        YAML.load_file(config_file_from_gem)
+        @default_tools ||= YAML.load_file(config_file_from_gem)
       end
 
       def custom_tools
         # Returns an empty hash if config file is empty
-        YAML.load_file(config_file_from_project) || {}
+        @custom_tools ||= YAML.load_file(config_file_from_project) || {}
 
       # When there is no config file in the project
       rescue Errno::ENOENT

--- a/lib/massa/version.rb
+++ b/lib/massa/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Massa
-  VERSION = '0.1.5'
+  VERSION = '0.1.6'
 end


### PR DESCRIPTION
If `massa.yml` in your project is empty, then `default_tools.yml` file will be used.

Added new attribute `gem` to yaml node. If `gem` = `true` it means Massa will check gem installation.

_Example 1:_

```
npm:
  description: 'NPM'
  command:  'npm run travis'
  required: false
  gem: false
```

Now `required` & `gem` are optional attributes. If you don't put it to config file, it means they are `true` by default.

_Example 2_

```
rubocop:
  description: 'Rubocop'
  command:     'bundle exec rubocop -c .rubocop_travis.yml'
```

**Changes:**
Introduced Massa::Command entity
Changed configuration logic
Added support of 'non-gem' commands
